### PR TITLE
move ngx_config.h and ngx_core.h to top of ngx_rtp_cenc.c

### DIFF
--- a/dash/ngx_rtmp_cenc.c
+++ b/dash/ngx_rtmp_cenc.c
@@ -1,10 +1,10 @@
 
 
+#include <ngx_config.h>
+#include <ngx_core.h>
 #include <openssl/aes.h>
 #include <openssl/rand.h>
 #include <openssl/evp.h>
-#include <ngx_config.h>
-#include <ngx_core.h>
 #include <ngx_rtmp.h>
 #include "ngx_rtmp_cenc.h"
 


### PR DESCRIPTION
I haven't figure out why or how, but I get this error when compiling in openwrt:
```
In file included from src/os/unix/ngx_process.h:12:0,
                 from src/core/ngx_core.h:54,
                 from /home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/nginx-all-module/nginx-1.15.6/nginx-rtmp/dash/ngx_rtmp_cenc.c:7:
src/os/unix/ngx_setaffinity.h:16:9: error: unknown type name 'cpu_set_t'
 typedef cpu_set_t  ngx_cpuset_t;
         ^~~~~~~~~
```
If I change the order of the includes, it works.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>