### PR TITLE
Multiple bitrate support for DASH audio in .mpd manifest

### DIFF
--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -782,7 +782,7 @@ ngx_rtmp_dash_write_variant_playlist(ngx_rtmp_session_t *s)
 
         for (j = 0; j < dacf->variant->nelts; j++, var++) {
             if (dacf->nested) {
-                *ngx_sprintf(audio_path, "%V%V",
+                *ngx_sprintf(audio_path, "%V%V/",
                              &ctx->varname, &var->suffix) = 0;
             } else {
                 *ngx_sprintf(audio_path, "%V%V%s",

--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -782,7 +782,7 @@ ngx_rtmp_dash_write_variant_playlist(ngx_rtmp_session_t *s)
 
         for (j = 0; j < dacf->variant->nelts; j++, var++) {
             if (dacf->nested) {
-                *ngx_sprintf(audio_path, "%V%V/",
+                *ngx_sprintf(audio_path, "%V%V",
                              &ctx->varname, &var->suffix) = 0;
             } else {
                 *ngx_sprintf(audio_path, "%V%V%s",

--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -116,12 +116,14 @@ typedef struct {
 #define NGX_RTMP_DASH_CLOCK_COMPENSATION_NTP       2
 #define NGX_RTMP_DASH_CLOCK_COMPENSATION_HTTP_HEAD 3
 #define NGX_RTMP_DASH_CLOCK_COMPENSATION_HTTP_ISO  4
+#define NGX_RTMP_DASH_CLOCK_COMPENSATION_HTTP_XSDATE  5
 
 static ngx_conf_enum_t                  ngx_rtmp_dash_clock_compensation_type_slots[] = {
     { ngx_string("off"),                NGX_RTMP_DASH_CLOCK_COMPENSATION_OFF },
     { ngx_string("ntp"),                NGX_RTMP_DASH_CLOCK_COMPENSATION_NTP },
     { ngx_string("http_head"),          NGX_RTMP_DASH_CLOCK_COMPENSATION_HTTP_HEAD },
     { ngx_string("http_iso"),           NGX_RTMP_DASH_CLOCK_COMPENSATION_HTTP_ISO },
+    { ngx_string("http_xsdate"),        NGX_RTMP_DASH_CLOCK_COMPENSATION_HTTP_XSDATE },
     { ngx_null_string,                  0 }
 };
 
@@ -863,6 +865,13 @@ ngx_rtmp_dash_write_variant_playlist(ngx_rtmp_session_t *s)
         case NGX_RTMP_DASH_CLOCK_COMPENSATION_HTTP_ISO:
                 p = ngx_slprintf(buffer, last, NGX_RTMP_DASH_MANIFEST_CLOCK,
                                  "http-iso",
+                                 &dacf->clock_helper_uri
+                );
+                n = ngx_write_fd(fd, buffer, p - buffer);
+        break;
+        case NGX_RTMP_DASH_CLOCK_COMPENSATION_HTTP_XSDATE:
+                p = ngx_slprintf(buffer, last, NGX_RTMP_DASH_MANIFEST_CLOCK,
+                                 "http-xsdate",
                                  &dacf->clock_helper_uri
                 );
                 n = ngx_write_fd(fd, buffer, p - buffer);

--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -751,6 +751,8 @@ ngx_rtmp_dash_write_variant_playlist(ngx_rtmp_session_t *s)
         n = ngx_write_fd(fd, buffer, p - buffer);
     }
 
+    var = dacf->variant->elts;
+
     if (ctx->has_audio) {
         p = ngx_slprintf(buffer, last, NGX_RTMP_DASH_MANIFEST_ADAPTATIONSET_AUDIO);
 
@@ -758,18 +760,44 @@ ngx_rtmp_dash_write_variant_playlist(ngx_rtmp_session_t *s)
             p = ngx_rtmp_dash_write_content_protection(s, &ctx->drm_info, p, last);
         }
 
-        p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_REPRESENTATION_AUDIO,
-                         &ctx->name,
+        ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                          "dash: attempting to read dash segments during audio processing '%s'", seg_path);
+
+        for (j = 0; j < dacf->variant->nelts; j++, var++) {
+            ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                          "dash: AUDIO SEGMENT j = '%d'", j);
+            if (dacf->nested) {
+                *ngx_sprintf(seg_path, "%V%V/",
+                             &ctx->varname, &var->suffix) = 0;
+            } else {
+                *ngx_sprintf(seg_path, "%V%V%s",
+                             &ctx->varname, &var->suffix, sep) = 0;
+            }
+
+            ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+                          "dash: read audio segments file for variant '%s'", seg_path);
+
+            p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_REPRESENTATION_VARIANT_AUDIO,
+                         seg_path,
                          codec_ctx->audio_codec_id == NGX_RTMP_AUDIO_AAC ?
                          (codec_ctx->aac_sbr ? "40.5" : "40.2") : "6b",
-                         codec_ctx->sample_rate,
-                         (ngx_uint_t) (codec_ctx->audio_data_rate * 1000),
-                         &ctx->name, sep,
-                         &ctx->name, sep);
+                         codec_ctx->sample_rate);
 
-        p = ngx_rtmp_dash_write_segment_timeline(s, ctx, dacf, p, last);
+            arg = var->args.elts;
+            for (k = 0; k < var->args.nelts && k < 1 ; k++, arg++) {
+                p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_VARIANT_ARG, arg);
+            }
 
-        p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_REPRESENTATION_AUDIO_FOOTER);
+            p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_VARIANT_ARG_FOOTER);
+
+            p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_SEGMENTTPL_VARIANT_AUDIO,
+                         seg_path,
+                         seg_path);
+
+            p = ngx_rtmp_dash_write_segment_timeline(s, ctx, dacf, p, last);
+
+            p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_REPRESENTATION_AUDIO_FOOTER);
+        }
 
         p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_ADAPTATIONSET_AUDIO_FOOTER);
 

--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -428,6 +428,9 @@ ngx_rtmp_dash_write_segment_timeline(ngx_rtmp_session_t *s, ngx_rtmp_dash_ctx_t 
     ngx_rtmp_dash_app_conf_t *dacf, u_char *p, u_char *last)
 {
     ngx_uint_t              i, t, d, r;
+    t=0;
+    d=0;
+    r=0;
     ngx_rtmp_dash_frag_t    *f;
 
     for (i = 0; i < ctx->nfrags; i++) {
@@ -1988,6 +1991,7 @@ ngx_rtmp_dash_append(ngx_rtmp_session_t *s, ngx_chain_t *in,
 
     p = buffer;
     size = 0;
+    csize = 0;
 
     for (; in && size < sizeof(buffer); in = in->next) {
 

--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -760,12 +760,7 @@ ngx_rtmp_dash_write_variant_playlist(ngx_rtmp_session_t *s)
             p = ngx_rtmp_dash_write_content_protection(s, &ctx->drm_info, p, last);
         }
 
-        ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                          "dash: attempting to read dash segments during audio processing '%s'", seg_path);
-
         for (j = 0; j < dacf->variant->nelts; j++, var++) {
-            ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                          "dash: AUDIO SEGMENT j = '%d'", j);
             if (dacf->nested) {
                 *ngx_sprintf(seg_path, "%V%V/",
                              &ctx->varname, &var->suffix) = 0;

--- a/dash/ngx_rtmp_dash_templates.h
+++ b/dash/ngx_rtmp_dash_templates.h
@@ -109,6 +109,8 @@
 #define NGX_RTMP_DASH_MANIFEST_VARIANT_ARG                                     \
     "          %V\n"
 
+#define NGX_RTMP_DASH_MANIFEST_VARIANT_ARG_CHAR                                \
+    "          %s\n"
 
 #define NGX_RTMP_DASH_MANIFEST_VARIANT_ARG_FOOTER                              \
     "          >\n"

--- a/dash/ngx_rtmp_dash_templates.h
+++ b/dash/ngx_rtmp_dash_templates.h
@@ -206,6 +206,8 @@
 
 
 #define NGX_RTMP_DASH_MANIFEST_FOOTER                                          \
+    "  <UTCTiming schemeIdUri=\"urn:mpeg:dash:utc:http-xsdate:2014\"\n"        \
+    "       value=\"https://goy-api.isha.in/rawServerTime\" />\n"              \
     "</MPD>\n"
 
 

--- a/dash/ngx_rtmp_dash_templates.h
+++ b/dash/ngx_rtmp_dash_templates.h
@@ -156,7 +156,7 @@
 
 #define NGX_RTMP_DASH_MANIFEST_REPRESENTATION_AUDIO                            \
     "      <Representation\n"                                                  \
-    "          id=\"%V_AAC\"\n"                                                \
+    "          id=\"%s_AAC\"\n"                                                \
     "          mimeType=\"audio/mp4\"\n"                                       \
     "          codecs=\"mp4a.%s\"\n"                                           \
     "          audioSamplingRate=\"%ui\"\n"                                    \
@@ -164,8 +164,23 @@
     "        <SegmentTemplate\n"                                               \
     "            presentationTimeOffset=\"0\"\n"                               \
     "            timescale=\"1000\"\n"                                         \
-    "            media=\"%V%s$Time$.m4a\"\n"                                   \
-    "            initialization=\"%V%sinit.m4a\">\n"                           \
+    "            media=\"%s$Time$.m4a\"\n"                                   \
+    "            initialization=\"%sinit.m4a\">\n"                           \
+    "          <SegmentTimeline>\n"
+
+#define NGX_RTMP_DASH_MANIFEST_REPRESENTATION_VARIANT_AUDIO                    \
+    "      <Representation\n"                                                  \
+    "          id=\"%s_AAC\"\n"                                                \
+    "          mimeType=\"audio/mp4\"\n"                                       \
+    "          codecs=\"mp4a.%s\"\n"                                           \
+    "          audioSamplingRate=\"%ui\"\n"
+
+#define NGX_RTMP_DASH_MANIFEST_SEGMENTTPL_VARIANT_AUDIO                        \
+    "        <SegmentTemplate\n"                                               \
+    "            presentationTimeOffset=\"0\"\n"                               \
+    "            timescale=\"1000\"\n"                                         \
+    "            media=\"%s$Time$.m4a\"\n"                                   \
+    "            initialization=\"%sinit.m4a\">\n"                           \
     "          <SegmentTimeline>\n"
 
 


### PR DESCRIPTION
This update adds support for multiple audio bitrates for DASH manifests.

This seems to otherwise function correctly, but there is one issue: segment timeline chunks get mismatched from actual files written to disk, if some variants have different frame rates than others. 
Example:
![WhatsApp Image 2021-05-19 at 22 43 54](https://user-images.githubusercontent.com/939056/118879488-7557fc00-b8f9-11eb-9845-806cc7cd14df.jpeg)
Any idea how this could be fixed?